### PR TITLE
Add Xamarin.Forms MVVM example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Build results
+bin/
+obj/
+# Visual Studio files
+*.user
+*.suo
+# Mac build
+*.app
+# Android build
+*.apk

--- a/HelloXamarin/App.xaml
+++ b/HelloXamarin/App.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Application xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HelloXamarin.App"
+             xmlns:views="clr-namespace:HelloXamarin.Views">
+  <Application.MainPage>
+    <NavigationPage>
+      <x:Arguments>
+        <views:MainPage />
+      </x:Arguments>
+    </NavigationPage>
+  </Application.MainPage>
+</Application>

--- a/HelloXamarin/App.xaml.cs
+++ b/HelloXamarin/App.xaml.cs
@@ -1,0 +1,12 @@
+using Xamarin.Forms;
+
+namespace HelloXamarin
+{
+    public partial class App : Application
+    {
+        public App()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/HelloXamarin/HelloXamarin.csproj
+++ b/HelloXamarin/HelloXamarin.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="5.0.0.2622" />
+  </ItemGroup>
+</Project>

--- a/HelloXamarin/ViewModels/MainViewModel.cs
+++ b/HelloXamarin/ViewModels/MainViewModel.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Xamarin.Forms;
+
+namespace HelloXamarin.ViewModels
+{
+    public class MainViewModel : INotifyPropertyChanged
+    {
+        private string nombre;
+        private string saludo;
+
+        public string Nombre
+        {
+            get => nombre;
+            set
+            {
+                if (nombre != value)
+                {
+                    nombre = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string Saludo
+        {
+            get => saludo;
+            set
+            {
+                if (saludo != value)
+                {
+                    saludo = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public ICommand SaludarCommand { get; }
+
+        public MainViewModel()
+        {
+            SaludarCommand = new Command(Saludar);
+        }
+
+        private void Saludar()
+        {
+            Saludo = $"Hola, {Nombre}";
+        }
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/HelloXamarin/Views/MainPage.xaml
+++ b/HelloXamarin/Views/MainPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="HelloXamarin.Views.MainPage">
+    <StackLayout Padding="20">
+        <Entry Placeholder="Nombre" Text="{Binding Nombre}" />
+        <Button Text="Saludar" Command="{Binding SaludarCommand}" />
+        <Label Text="{Binding Saludo}" />
+    </StackLayout>
+</ContentPage>

--- a/HelloXamarin/Views/MainPage.xaml.cs
+++ b/HelloXamarin/Views/MainPage.xaml.cs
@@ -1,0 +1,14 @@
+using Xamarin.Forms;
+using HelloXamarin.ViewModels;
+
+namespace HelloXamarin.Views
+{
+    public partial class MainPage : ContentPage
+    {
+        public MainPage()
+        {
+            InitializeComponent();
+            BindingContext = new MainViewModel();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # CursoCenfotec
+
+Este proyecto contiene un ejemplo basico de Xamarin.Forms utilizando el patron MVVM.
+
+## Estructura
+- `HelloXamarin` contiene el proyecto .NET Standard donde se define la interfaz compartida.
+
+Para compilar y ejecutar es necesario tener instalado **.NET** con soporte para Xamarin y las herramientas de plataforma correspondientes (Android/iOS). Debido a que este repositorio no incluye proyectos de plataforma, debera agregarse una aplicacion Android/iOS que haga referencia a `HelloXamarin`.


### PR DESCRIPTION
## Summary
- add sample Xamarin.Forms project with MVVM pattern
- implement `MainViewModel` with `Nombre` property and greeting command
- create `MainPage` bound to the view model
- update README with build information

## Testing
- `dotnet build HelloXamarin/HelloXamarin.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a35cc094832d91cf2cd9a266ff4e

## Summary by Sourcery

Introduce a new Xamarin.Forms sample project demonstrating the MVVM pattern with a view model, a bound page, and updated documentation.

New Features:
- Add HelloXamarin Xamarin.Forms project with .NET Standard shared interface
- Implement MainViewModel with Nombre and Saludo properties and a Saludar command
- Create MainPage view bound to MainViewModel as the app's entry point

Documentation:
- Update README with an overview in Spanish and project structure details